### PR TITLE
Add support for NAPTR record

### DIFF
--- a/dns/client.go
+++ b/dns/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strconv"
 
 	"github.com/miekg/dns"
 )
@@ -90,6 +91,8 @@ func (r *Client) Resolve(
 			ips = append(ips, t.A.String())
 		case *dns.AAAA:
 			ips = append(ips, t.AAAA.String())
+		case *dns.NAPTR:
+			ips = append(ips, fmtNAPTRAnswer(t))
 		default:
 			return nil, fmt.Errorf(
 				"resolve operation failed with %w: unhandled DNS answer type %T",
@@ -111,4 +114,14 @@ func (r *Client) Lookup(ctx context.Context, hostname string) ([]string, error) 
 	}
 
 	return ips, nil
+}
+
+// Format NAPTR answer.
+func fmtNAPTRAnswer(answer *dns.NAPTR) string {
+	return strconv.Itoa(int(answer.Order)) + " " +
+		strconv.Itoa(int(answer.Preference)) + " " +
+		"\"" + answer.Flags + "\" " +
+		"\"" + answer.Service + "\" " +
+		"\"" + answer.Regexp + "\" " +
+		answer.Replacement
 }

--- a/dns/record_type.go
+++ b/dns/record_type.go
@@ -10,6 +10,7 @@ import "github.com/miekg/dns"
 // The currently supported values are:
 // - A
 // - AAAA
+// - NAPTR
 //
 // The supported values are the ones that are most likely to be
 // used by the users of this extension and package, as they are
@@ -30,6 +31,7 @@ type RecordType uint16
 // Note that the RecordType enum values are explicitly typed to allow enumer
 // to detect them.
 const (
-	RecordTypeA    RecordType = RecordType(dns.TypeA)
-	RecordTypeAAAA RecordType = RecordType(dns.TypeAAAA)
+	RecordTypeA     RecordType = RecordType(dns.TypeA)
+	RecordTypeAAAA  RecordType = RecordType(dns.TypeAAAA)
+	RecordTypeNAPTR RecordType = RecordType(dns.TypeNAPTR)
 )

--- a/dns/record_type_gen.go
+++ b/dns/record_type_gen.go
@@ -9,11 +9,13 @@ import (
 const (
 	_RecordTypeName_0 = "A"
 	_RecordTypeName_1 = "AAAA"
+	_RecordTypeName_2 = "NAPTR"
 )
 
 var (
 	_RecordTypeIndex_0 = [...]uint8{0, 1}
 	_RecordTypeIndex_1 = [...]uint8{0, 4}
+	_RecordTypeIndex_2 = [...]uint8{0, 5}
 )
 
 func (i RecordType) String() string {
@@ -22,16 +24,19 @@ func (i RecordType) String() string {
 		return _RecordTypeName_0
 	case i == 28:
 		return _RecordTypeName_1
+	case i == 35:
+		return _RecordTypeName_2
 	default:
 		return fmt.Sprintf("RecordType(%d)", i)
 	}
 }
 
-var _RecordTypeValues = []RecordType{1, 28}
+var _RecordTypeValues = []RecordType{1, 28, 35}
 
 var _RecordTypeNameToValueMap = map[string]RecordType{
 	_RecordTypeName_0[0:1]: 1,
 	_RecordTypeName_1[0:4]: 28,
+	_RecordTypeName_2[0:5]: 35,
 }
 
 // RecordTypeString retrieves an enum value from the enum constants string name.


### PR DESCRIPTION
This PR add support for NAPTR record type.
NAPTR query takes an E164 phone number (0123456789) in the format of "9.8.7.6.5.4.3.2.1.0.e164.arpa.", and return a record pertaining to routing the phone number to the correct service provider (100 10 "U" "E2U+sip" "!^.*$!sip:customer-service@example.com!" .)