### PR TITLE
Add support for NAPTR record

### DIFF
--- a/dns/client.go
+++ b/dns/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strconv"
 
 	"github.com/miekg/dns"
 )
@@ -90,6 +91,8 @@ func (r *Client) Resolve(
 			ips = append(ips, t.A.String())
 		case *dns.AAAA:
 			ips = append(ips, t.AAAA.String())
+		case *dns.NAPTR:
+			ips = append(ips, fmtNAPTRAnswer(t))
 		default:
 			return nil, fmt.Errorf(
 				"resolve operation failed with %w: unhandled DNS answer type %T",
@@ -111,4 +114,14 @@ func (r *Client) Lookup(ctx context.Context, hostname string) ([]string, error) 
 	}
 
 	return ips, nil
+}
+
+// Format NAPTR answer.
+func fmtNAPTRAnswer(answer *dns.NAPTR) string {
+	return strconv.Itoa(int(answer.Order)) + " " +
+		strconv.Itoa(int(answer.Preference)) + " " +
+		"\"" + answer.Flags + "\" " +
+		"\"" + answer.Service + "\" " +
+		"\"" + answer.Regexp + "\" " +
+		answer.Replacement
 }

--- a/dns/module_test.go
+++ b/dns/module_test.go
@@ -61,7 +61,7 @@ const (
 	// primaryTestNAPTR.
 	testNAPTRDomain = "9.8.7.6.5.4.3.2.1.0.e164.arpa."
 
-	//primaryTestNAPTR is a default NAPTR response we configure our DNS ser ver to resolve the testNAPTRDomain to.
+	// primaryTestNAPTR is a default NAPTR response we configure our DNS ser ver to resolve the testNAPTRDomain to.
 	primaryTestNAPTR = "100 10 \"U\" \"E2U+sip\" \"!^.*$!sip:customer-service@example.com!\" ."
 )
 

--- a/dns/module_test.go
+++ b/dns/module_test.go
@@ -56,6 +56,13 @@ const (
 	// testDomain to. This points to the same IP as secondaryTestIPv4, and is subject to the same routing
 	// constraints.
 	secondaryTestIPv6 = "fd61:76ff:fe12:3456:789a:bcde:f012:6789"
+
+	// testNAPTRDomain is the domain name we configure our test DNS server to resolve to the
+	// primaryTestNAPTR.
+	testNAPTRDomain = "9.8.7.6.5.4.3.2.1.0.e164.arpa."
+
+	//primaryTestNAPTR is a default NAPTR response we configure our DNS ser ver to resolve the testNAPTRDomain to.
+	primaryTestNAPTR = "100 10 \"U\" \"E2U+sip\" \"!^.*$!sip:customer-service@example.com!\" ."
 )
 
 func TestClient_Resolve(t *testing.T) {
@@ -292,6 +299,100 @@ func TestClient_Resolve(t *testing.T) {
 		_, err = runtime.RunOnEventLoop(wrapInAsyncLambda(testScript))
 		assert.NoError(t, err)
 	})
+
+	t.Run("Resolving existing NAPTR records against test nameserver should succeed", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		unboundContainer, mappedPort := startUnboundContainer(ctx, t)
+		defer func() {
+			if err := unboundContainer.Terminate(ctx); err != nil {
+				t.Fatalf("could not stop unbound: %s", err.Error())
+			}
+		}()
+
+		runtime, err := newConfiguredRuntime(t)
+		require.NoError(t, err)
+
+		// Setting up the runtime with the necessary state to execute in the VU context
+		runtime.MoveToVUContext(&lib.State{
+			BuiltinMetrics: metrics.RegisterBuiltinMetrics(metrics.NewRegistry()),
+			Tags:           lib.NewVUStateTags(metrics.NewRegistry().RootTagSet().With("tag-vu", "mytag")),
+			Samples:        make(chan metrics.SampleContainer, 8),
+		})
+
+		testScript := `
+			const resolveResults = await dns.resolve(
+				"` + testNAPTRDomain + `",
+				"` + RecordTypeNAPTR.String() + `",
+				"127.0.0.1:` + strconv.Itoa(mappedPort.Int()) + `"
+			);
+		
+			// We sort the results to ensure that the order is consistent
+			// and we can compare the results with the expected values
+			resolveResults.sort();
+		
+			if (resolveResults.length === 0) {
+				throw "Resolving 9.8.7.6.5.4.3.2.1.0.e164.arpa. against unbound server test container returned no results, expected ['` + primaryTestNAPTR + `']"
+			}
+			
+			if (resolveResults.length !== 1) {
+				throw "Resolving 9.8.7.6.5.4.3.2.1.0.e164.arpa. against unbound server test container returned an unexpected number of results, expected 1 record, got:" + resolveResults.length
+			}
+		
+			if (resolveResults[0] !== "` + primaryTestIPv6 + `") {
+				throw "Resolving 9.8.7.6.5.4.3.2.1.0.e164.arpa. against unbound server test container returned unexpected result, expected '` + primaryTestNAPTR + `', got " + resolveResults[0]
+			}
+		
+		`
+
+		_, err = runtime.RunOnEventLoop(wrapInAsyncLambda(testScript))
+		assert.NoError(t, err)
+	})
+
+	t.Run("Resolving non-existing NAPTR records against test nameserver should succeed", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		unboundContainer, mappedPort := startUnboundContainer(ctx, t)
+		defer func() {
+			if err := unboundContainer.Terminate(ctx); err != nil {
+				t.Fatalf("could not stop unbound: %s", err.Error())
+			}
+		}()
+
+		runtime, err := newConfiguredRuntime(t)
+		require.NoError(t, err)
+
+		// Setting up the runtime with the necessary state to execute in the VU context
+		runtime.MoveToVUContext(&lib.State{
+			BuiltinMetrics: metrics.RegisterBuiltinMetrics(metrics.NewRegistry()),
+			Tags:           lib.NewVUStateTags(metrics.NewRegistry().RootTagSet().With("tag-vu", "mytag")),
+			Samples:        make(chan metrics.SampleContainer, 8),
+		})
+
+		testScript := `
+			try {
+				const resolvedResults = await dns.resolve(
+					"missing.domain",
+					"` + RecordTypeNAPTR.String() + `",
+					"127.0.0.1:` + strconv.Itoa(mappedPort.Int()) + `"
+				);
+			} catch (err) {
+				if (err.name !== "NonExistingDomain") {
+					throw "Resolving missing.domain against unbound server test container returned unexpected error, expected NonExistingDomain, got: " + err.Name
+				}
+		
+				// We expected this error, so we can return
+				return
+			}
+		
+			throw "Resolving missing.domain against unbound server test container should have thrown an error, but it didn't"
+		`
+
+		_, err = runtime.RunOnEventLoop(wrapInAsyncLambda(testScript))
+		assert.NoError(t, err)
+	})
 }
 
 func TestClient_Lookup(t *testing.T) {
@@ -377,6 +478,7 @@ func startUnboundContainer(ctx context.Context, t *testing.T) (runningContainer 
 		unboundRecord{testDomain, RecordTypeA.String(), secondaryTestIPv4},
 		unboundRecord{testDomain, RecordTypeAAAA.String(), primaryTestIPv6},
 		unboundRecord{testDomain, RecordTypeAAAA.String(), secondaryTestIPv6},
+		unboundRecord{testNAPTRDomain, RecordTypeNAPTR.String(), primaryTestNAPTR},
 	)
 
 	network := testcontainers.DockerNetwork{Name: "testcontainers"}

--- a/dns/record_type.go
+++ b/dns/record_type.go
@@ -10,6 +10,7 @@ import "github.com/miekg/dns"
 // The currently supported values are:
 // - A
 // - AAAA
+// - NAPTR
 //
 // The supported values are the ones that are most likely to be
 // used by the users of this extension and package, as they are
@@ -30,6 +31,7 @@ type RecordType uint16
 // Note that the RecordType enum values are explicitly typed to allow enumer
 // to detect them.
 const (
-	RecordTypeA    RecordType = RecordType(dns.TypeA)
-	RecordTypeAAAA RecordType = RecordType(dns.TypeAAAA)
+	RecordTypeA     RecordType = RecordType(dns.TypeA)
+	RecordTypeAAAA  RecordType = RecordType(dns.TypeAAAA)
+	RecordTypeNAPTR RecordType = RecordType(dns.TypeNAPTR)
 )

--- a/dns/record_type_gen.go
+++ b/dns/record_type_gen.go
@@ -9,11 +9,13 @@ import (
 const (
 	_RecordTypeName_0 = "A"
 	_RecordTypeName_1 = "AAAA"
+	_RecordTypeName_2 = "NAPTR"
 )
 
 var (
 	_RecordTypeIndex_0 = [...]uint8{0, 1}
 	_RecordTypeIndex_1 = [...]uint8{0, 4}
+	_RecordTypeIndex_2 = [...]uint8{0, 5}
 )
 
 func (i RecordType) String() string {
@@ -22,16 +24,19 @@ func (i RecordType) String() string {
 		return _RecordTypeName_0
 	case i == 28:
 		return _RecordTypeName_1
+	case i == 35:
+		return _RecordTypeName_2
 	default:
 		return fmt.Sprintf("RecordType(%d)", i)
 	}
 }
 
-var _RecordTypeValues = []RecordType{1, 28}
+var _RecordTypeValues = []RecordType{1, 28, 35}
 
 var _RecordTypeNameToValueMap = map[string]RecordType{
 	_RecordTypeName_0[0:1]: 1,
 	_RecordTypeName_1[0:4]: 28,
+	_RecordTypeName_2[0:5]: 35,
 }
 
 // RecordTypeString retrieves an enum value from the enum constants string name.


### PR DESCRIPTION
This PR add support for NAPTR record type.
NAPTR query takes an E164 phone number (0123456789) in the format of "9.8.7.6.5.4.3.2.1.0.e164.arpa.", and return a record pertaining to routing the phone number to the correct service provider (100 10 "U" "E2U+sip" "!^.*$!sip:[customer-service@example.com](mailto:customer-service@example.com)!" .)