### PR TITLE
Add support to TXT records

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,13 @@ export const options = {
 };
 
 export default async function() {
-    // Request the IP address of k6.io from the selected namerserver A records.
+    // Request the IP address of k6.io from the selected nameserver A records.
     const resolvedIP = await dns.resolve('k6.io', 'A', '9.9.9.9:53');
     console.log(`k6.io IPs as resolved against the 9.9.9.9 nameserver: ${resolvedIP}`);
+
+    // Request the TXT records for k6.io from the selected nameserver.
+    const txtRecords = await dns.resolve('k6.io', 'TXT', '9.9.9.9:53');
+    console.log(`k6.io TXT records: ${txtRecords}`);
     
     // Lookup the IP address of k6.io using the system's default DNS server.
     const lookupIP = await dns.lookup('k6.io');
@@ -81,9 +85,9 @@ default ✓ [======================================] 10 VUs  00m00.2s/10m0s  200
 
 ### `dns.resolve(query, recordType, options)`
 
-Resolves a DNS name to an IP address using the provided DNS server. It returns an array of IP addresses.
+Resolves a DNS query using the provided DNS server. It returns an array of results: IP addresses for `A`/`AAAA` records, or strings for `TXT` records.
 
-The `query` parameter is the DNS name to resolve, the `recordType` parameter is the type of DNS record to query for (e.g. 'A', 'AAAA', 'CNAME', 'NS', and 'PTR'), and the `options` parameter is an object that can contain the following properties:
+The `query` parameter is the DNS name to resolve, the `recordType` parameter is the type of DNS record to query for (e.g. 'A', 'AAAA', 'TXT'), and the `options` parameter is an object that can contain the following properties:
 - `nameserver` - the IP address and port of the DNS server to query. It should be in the format `ip:port`. If not provided, the system's default DNS server will be used.
 
 Using the `dns.resolve()` operation will emit the following metrics:

--- a/dns/client.go
+++ b/dns/client.go
@@ -105,6 +105,7 @@ func (r *Client) Resolve(
 	// corresponding uint16 value.
 	message := dns.Msg{}
 	message.SetQuestion(query+".", uint16(concreteType))
+	message.SetEdns0(4096, false)
 
 	// Query the nameserver using k6's dialer
 	response, _, err := r.k6Client.ExchangeContext(ctx, &message, nameserver.Addr())
@@ -116,13 +117,15 @@ func (r *Client) Resolve(
 		return nil, newDNSError(response.Rcode, "DNS query failed")
 	}
 
-	var ips []string
+	var results []string
 	for _, a := range response.Answer {
 		switch t := a.(type) {
 		case *dns.A:
-			ips = append(ips, t.A.String())
+			results = append(results, t.A.String())
 		case *dns.AAAA:
-			ips = append(ips, t.AAAA.String())
+			results = append(results, t.AAAA.String())
+		case *dns.TXT:
+			results = append(results, t.Txt...)
 		default:
 			return nil, fmt.Errorf(
 				"resolve operation failed with %w: unhandled DNS answer type %T",
@@ -132,7 +135,7 @@ func (r *Client) Resolve(
 		}
 	}
 
-	return ips, nil
+	return results, nil
 }
 
 // Lookup resolves a domain name to a slice of IP addresses.

--- a/dns/client.go
+++ b/dns/client.go
@@ -125,7 +125,7 @@ func (r *Client) Resolve(
 		case *dns.AAAA:
 			results = append(results, t.AAAA.String())
 		case *dns.TXT:
-			results = append(results, t.Txt...)
+			results = append(results, strings.Join(t.Txt, ""))
 		default:
 			return nil, fmt.Errorf(
 				"resolve operation failed with %w: unhandled DNS answer type %T",

--- a/dns/errors_gen.go
+++ b/dns/errors_gen.go
@@ -4,11 +4,14 @@ package dns
 
 import (
 	"fmt"
+	"strings"
 )
 
 const (
-	_errorKindName_0 = "FormatErrorServerFailureNonExistingDomainNotImplementedRefusedYXDomainYXRrsetNXRrsetNotAuthNotZone"
-	_errorKindName_1 = "BadVersBadKeyBadTimeBadModeBadNameBadAlgBadTruncBadCookie"
+	_errorKindName_0      = "FormatErrorServerFailureNonExistingDomainNotImplementedRefusedYXDomainYXRrsetNXRrsetNotAuthNotZone"
+	_errorKindLowerName_0 = "formaterrorserverfailurenonexistingdomainnotimplementedrefusedyxdomainyxrrsetnxrrsetnotauthnotzone"
+	_errorKindName_1      = "BadVersBadKeyBadTimeBadModeBadNameBadAlgBadTruncBadCookie"
+	_errorKindLowerName_1 = "badversbadkeybadtimebadmodebadnamebadalgbadtruncbadcookie"
 )
 
 var (
@@ -29,27 +32,90 @@ func (i errorKind) String() string {
 	}
 }
 
-var _errorKindValues = []errorKind{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 16, 17, 18, 19, 20, 21, 22, 23}
+// An "invalid array index" compiler error signifies that the constant values have changed.
+// Re-run the stringer command to generate them again.
+func _errorKindNoOp() {
+	var x [1]struct{}
+	_ = x[FormatError-(1)]
+	_ = x[ServerFailure-(2)]
+	_ = x[NonExistingDomain-(3)]
+	_ = x[NotImplemented-(4)]
+	_ = x[Refused-(5)]
+	_ = x[YXDomain-(6)]
+	_ = x[YXRrset-(7)]
+	_ = x[NXRrset-(8)]
+	_ = x[NotAuth-(9)]
+	_ = x[NotZone-(10)]
+	_ = x[BadVers-(16)]
+	_ = x[BadKey-(17)]
+	_ = x[BadTime-(18)]
+	_ = x[BadMode-(19)]
+	_ = x[BadName-(20)]
+	_ = x[BadAlg-(21)]
+	_ = x[BadTrunc-(22)]
+	_ = x[BadCookie-(23)]
+}
+
+var _errorKindValues = []errorKind{FormatError, ServerFailure, NonExistingDomain, NotImplemented, Refused, YXDomain, YXRrset, NXRrset, NotAuth, NotZone, BadVers, BadKey, BadTime, BadMode, BadName, BadAlg, BadTrunc, BadCookie}
 
 var _errorKindNameToValueMap = map[string]errorKind{
-	_errorKindName_0[0:11]:  1,
-	_errorKindName_0[11:24]: 2,
-	_errorKindName_0[24:41]: 3,
-	_errorKindName_0[41:55]: 4,
-	_errorKindName_0[55:62]: 5,
-	_errorKindName_0[62:70]: 6,
-	_errorKindName_0[70:77]: 7,
-	_errorKindName_0[77:84]: 8,
-	_errorKindName_0[84:91]: 9,
-	_errorKindName_0[91:98]: 10,
-	_errorKindName_1[0:7]:   16,
-	_errorKindName_1[7:13]:  17,
-	_errorKindName_1[13:20]: 18,
-	_errorKindName_1[20:27]: 19,
-	_errorKindName_1[27:34]: 20,
-	_errorKindName_1[34:40]: 21,
-	_errorKindName_1[40:48]: 22,
-	_errorKindName_1[48:57]: 23,
+	_errorKindName_0[0:11]:       FormatError,
+	_errorKindLowerName_0[0:11]:  FormatError,
+	_errorKindName_0[11:24]:      ServerFailure,
+	_errorKindLowerName_0[11:24]: ServerFailure,
+	_errorKindName_0[24:41]:      NonExistingDomain,
+	_errorKindLowerName_0[24:41]: NonExistingDomain,
+	_errorKindName_0[41:55]:      NotImplemented,
+	_errorKindLowerName_0[41:55]: NotImplemented,
+	_errorKindName_0[55:62]:      Refused,
+	_errorKindLowerName_0[55:62]: Refused,
+	_errorKindName_0[62:70]:      YXDomain,
+	_errorKindLowerName_0[62:70]: YXDomain,
+	_errorKindName_0[70:77]:      YXRrset,
+	_errorKindLowerName_0[70:77]: YXRrset,
+	_errorKindName_0[77:84]:      NXRrset,
+	_errorKindLowerName_0[77:84]: NXRrset,
+	_errorKindName_0[84:91]:      NotAuth,
+	_errorKindLowerName_0[84:91]: NotAuth,
+	_errorKindName_0[91:98]:      NotZone,
+	_errorKindLowerName_0[91:98]: NotZone,
+	_errorKindName_1[0:7]:        BadVers,
+	_errorKindLowerName_1[0:7]:   BadVers,
+	_errorKindName_1[7:13]:       BadKey,
+	_errorKindLowerName_1[7:13]:  BadKey,
+	_errorKindName_1[13:20]:      BadTime,
+	_errorKindLowerName_1[13:20]: BadTime,
+	_errorKindName_1[20:27]:      BadMode,
+	_errorKindLowerName_1[20:27]: BadMode,
+	_errorKindName_1[27:34]:      BadName,
+	_errorKindLowerName_1[27:34]: BadName,
+	_errorKindName_1[34:40]:      BadAlg,
+	_errorKindLowerName_1[34:40]: BadAlg,
+	_errorKindName_1[40:48]:      BadTrunc,
+	_errorKindLowerName_1[40:48]: BadTrunc,
+	_errorKindName_1[48:57]:      BadCookie,
+	_errorKindLowerName_1[48:57]: BadCookie,
+}
+
+var _errorKindNames = []string{
+	_errorKindName_0[0:11],
+	_errorKindName_0[11:24],
+	_errorKindName_0[24:41],
+	_errorKindName_0[41:55],
+	_errorKindName_0[55:62],
+	_errorKindName_0[62:70],
+	_errorKindName_0[70:77],
+	_errorKindName_0[77:84],
+	_errorKindName_0[84:91],
+	_errorKindName_0[91:98],
+	_errorKindName_1[0:7],
+	_errorKindName_1[7:13],
+	_errorKindName_1[13:20],
+	_errorKindName_1[20:27],
+	_errorKindName_1[27:34],
+	_errorKindName_1[34:40],
+	_errorKindName_1[40:48],
+	_errorKindName_1[48:57],
 }
 
 // errorKindString retrieves an enum value from the enum constants string name.
@@ -58,12 +124,23 @@ func errorKindString(s string) (errorKind, error) {
 	if val, ok := _errorKindNameToValueMap[s]; ok {
 		return val, nil
 	}
+
+	if val, ok := _errorKindNameToValueMap[strings.ToLower(s)]; ok {
+		return val, nil
+	}
 	return 0, fmt.Errorf("%s does not belong to errorKind values", s)
 }
 
 // errorKindValues returns all values of the enum
 func errorKindValues() []errorKind {
 	return _errorKindValues
+}
+
+// errorKindStrings returns a slice of all String values of the enum
+func errorKindStrings() []string {
+	strs := make([]string, len(_errorKindNames))
+	copy(strs, _errorKindNames)
+	return strs
 }
 
 // IsAerrorKind returns "true" if the value is listed in the enum definition. "false" otherwise

--- a/dns/module.go
+++ b/dns/module.go
@@ -97,6 +97,23 @@ func (mi *ModuleInstance) Resolve(query, recordType, nameserverAddr sobek.Value)
 		return promise
 	}
 
+	ipAddrs, err := mi.dnsClient.Lookup(mi.vu.Context(), nameserverAddrStr)
+	if err != nil {
+		var customErr *Error
+
+		if errors.As(err, &customErr) && customErr.Name == "BlockedHostname" {
+			reject(fmt.Errorf("caught blocked host Message: %v", customErr.Message))
+			return promise
+		}
+	} else {
+		if len(ipAddrs) == 0 {
+			reject(fmt.Errorf("nameserver hostname %s resolved to no addresses", nameserverAddr))
+			return promise
+		}
+
+		nameserverAddrStr = ipAddrs[0]
+	}
+
 	nameserver, err := parseNameserverAddr(nameserverAddrStr)
 	if err != nil {
 		reject(fmt.Errorf("parsing nameserver address failed: %w", err))

--- a/dns/module.go
+++ b/dns/module.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"time"
 
 	"go.k6.io/k6/v2/js/common"
@@ -96,31 +95,6 @@ func (mi *ModuleInstance) Resolve(query, recordType, nameserverAddr sobek.Value)
 	if err := mi.vu.Runtime().ExportTo(nameserverAddr, &nameserverAddrStr); err != nil {
 		reject(fmt.Errorf("nameserver must be a string; got %v instead", nameserverAddr))
 		return promise
-	}
-
-	// Parse host/port first to check if it's already an IP
-	host, _, parseErr := parseHostAndPort(nameserverAddrStr)
-	if parseErr == nil && net.ParseIP(host) == nil {
-		// Host is not an IP, resolve it using k6's dialer
-		ipAddrs, lookupErr := mi.dnsClient.Lookup(mi.vu.Context(), host)
-		if lookupErr != nil {
-			var customErr *Error
-			if errors.As(lookupErr, &customErr) && customErr.Name == "BlockedHostname" {
-				reject(fmt.Errorf("caught blocked host Message: %v", customErr.Message))
-				return promise
-			}
-
-			reject(fmt.Errorf("failed to resolve nameserver hostname: %w", lookupErr))
-			return promise
-		}
-
-		if len(ipAddrs) == 0 {
-			reject(fmt.Errorf("nameserver hostname %s resolved to no addresses", host))
-			return promise
-		}
-
-		// Replace hostname with resolved IP, preserving original port
-		nameserverAddrStr = ipAddrs[0] + nameserverAddrStr[len(host):]
 	}
 
 	nameserver, err := parseNameserverAddr(nameserverAddrStr)

--- a/dns/module.go
+++ b/dns/module.go
@@ -108,7 +108,7 @@ func (mi *ModuleInstance) Resolve(query, recordType, nameserverAddr sobek.Value)
 		resolutionStartTime := time.Now()
 
 		// Resolve the query
-		fetchedIPs, resolveErr := mi.dnsClient.Resolve(mi.vu.Context(), queryStr, recordTypeStr, nameserver)
+		results, resolveErr := mi.dnsClient.Resolve(mi.vu.Context(), queryStr, recordTypeStr, nameserver)
 
 		// Stop the timer for resolution
 		sinceResolutionStart := time.Since(resolutionStartTime).Milliseconds()
@@ -129,7 +129,7 @@ func (mi *ModuleInstance) Resolve(query, recordType, nameserverAddr sobek.Value)
 			return
 		}
 
-		resolve(fetchedIPs)
+		resolve(results)
 	}()
 
 	return promise

--- a/dns/module.go
+++ b/dns/module.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"time"
 
 	"go.k6.io/k6/v2/js/common"
@@ -97,21 +98,29 @@ func (mi *ModuleInstance) Resolve(query, recordType, nameserverAddr sobek.Value)
 		return promise
 	}
 
-	ipAddrs, err := mi.dnsClient.Lookup(mi.vu.Context(), nameserverAddrStr)
-	if err != nil {
-		var customErr *Error
+	// Parse host/port first to check if it's already an IP
+	host, _, parseErr := parseHostAndPort(nameserverAddrStr)
+	if parseErr == nil && net.ParseIP(host) == nil {
+		// Host is not an IP, resolve it using k6's dialer
+		ipAddrs, lookupErr := mi.dnsClient.Lookup(mi.vu.Context(), host)
+		if lookupErr != nil {
+			var customErr *Error
+			if errors.As(lookupErr, &customErr) && customErr.Name == "BlockedHostname" {
+				reject(fmt.Errorf("caught blocked host Message: %v", customErr.Message))
+				return promise
+			}
 
-		if errors.As(err, &customErr) && customErr.Name == "BlockedHostname" {
-			reject(fmt.Errorf("caught blocked host Message: %v", customErr.Message))
+			reject(fmt.Errorf("failed to resolve nameserver hostname: %w", lookupErr))
 			return promise
 		}
-	} else {
+
 		if len(ipAddrs) == 0 {
-			reject(fmt.Errorf("nameserver hostname %s resolved to no addresses", nameserverAddr))
+			reject(fmt.Errorf("nameserver hostname %s resolved to no addresses", host))
 			return promise
 		}
 
-		nameserverAddrStr = ipAddrs[0]
+		// Replace hostname with resolved IP, preserving original port
+		nameserverAddrStr = ipAddrs[0] + nameserverAddrStr[len(host):]
 	}
 
 	nameserver, err := parseNameserverAddr(nameserverAddrStr)

--- a/dns/module_test.go
+++ b/dns/module_test.go
@@ -49,6 +49,10 @@ const (
 	// testDomain to. This points to the same IP as secondaryTestIPv4, and is subject to the same routing
 	// constraints.
 	secondaryTestIPv6 = "fd61:76ff:fe12:3456:789a:bcde:f012:6789"
+
+	// primaryTestTXT is a TXT record value we configure our test DNS server to resolve
+	// the testDomain to.
+	primaryTestTXT = "v=spf1 include:example.com ~all"
 )
 
 func TestClient_Resolve(t *testing.T) {
@@ -236,6 +240,68 @@ func TestClient_Resolve(t *testing.T) {
 			}
 		
 			throw "Resolving missing.domain against unbound server test container should have thrown an error, but it didn't"
+		`
+
+		_, err = runtime.RunOnEventLoop(wrapInAsyncLambda(testScript))
+		assert.NoError(t, err)
+	})
+
+	t.Run("Resolving existing TXT records against test nameserver should succeed", func(t *testing.T) {
+		t.Parallel()
+
+		port, _ := startTestDNSServer(t)
+
+		runtime, err := newConfiguredRuntime(t)
+		require.NoError(t, err)
+
+		runtime.MoveToVUContext(newTestVUState())
+
+		testScript := `
+			const resolveResults = await dns.resolve(
+				"` + testDomain + `",
+				"` + RecordTypeTXT.String() + `",
+				"127.0.0.1:` + port + `"
+			);
+		
+			if (resolveResults.length === 0) {
+				throw "Resolving ` + testDomain + ` TXT against test nameserver returned no results, expected at least one TXT record"
+			}
+		
+			if (resolveResults[0] !== "` + primaryTestTXT + `") {
+				throw "Resolving ` + testDomain + ` TXT against test nameserver returned unexpected result, expected '` + primaryTestTXT + `', got " + resolveResults[0]
+			}
+		`
+
+		_, err = runtime.RunOnEventLoop(wrapInAsyncLambda(testScript))
+		assert.NoError(t, err)
+	})
+
+	t.Run("Resolving non-existing TXT records against test nameserver should succeed", func(t *testing.T) {
+		t.Parallel()
+
+		port, _ := startTestDNSServer(t)
+
+		runtime, err := newConfiguredRuntime(t)
+		require.NoError(t, err)
+
+		runtime.MoveToVUContext(newTestVUState())
+
+		testScript := `
+			try {
+				const resolvedResults = await dns.resolve(
+					"missing.domain",
+					"` + RecordTypeTXT.String() + `",
+					"127.0.0.1:` + port + `"
+				);
+			} catch (err) {
+				if (err.name !== "NonExistingDomain") {
+					throw "Resolving missing.domain TXT against test nameserver returned unexpected error, expected NonExistingDomain, got: " + err.name
+				}
+		
+				return
+			}
+		
+			throw "Resolving missing.domain TXT against test nameserver should have thrown an error, but it didn't"
 		`
 
 		_, err = runtime.RunOnEventLoop(wrapInAsyncLambda(testScript))
@@ -746,8 +812,8 @@ func wrapInAsyncLambda(input string) string {
 }
 
 // startTestDNSServer starts small UDP DNS servers on random ports of
-// 127.0.0.1 and [::1] sharing the same handler — they answer A/AAAA queries
-// for testDomain with the test IPs, and return NXDOMAIN for anything else.
+// 127.0.0.1 and [::1] sharing the same handler — they answer A/AAAA/TXT queries
+// for testDomain with the test IPs and TXT records, and return NXDOMAIN for anything else.
 // Both listeners shut down via t.Cleanup.
 //
 // In-process via miekg/dns; no Docker dependency, works identically on every
@@ -758,6 +824,7 @@ func startTestDNSServer(t *testing.T) (ipv4Port, ipv6Port string) {
 	records := map[uint16][]string{
 		miekgdns.TypeA:    {primaryTestIPv4, secondaryTestIPv4},
 		miekgdns.TypeAAAA: {primaryTestIPv6, secondaryTestIPv6},
+		miekgdns.TypeTXT:  {primaryTestTXT},
 	}
 
 	handler := miekgdns.HandlerFunc(func(w miekgdns.ResponseWriter, r *miekgdns.Msg) {
@@ -775,6 +842,8 @@ func startTestDNSServer(t *testing.T) (ipv4Port, ipv6Port string) {
 					m.Answer = append(m.Answer, &miekgdns.A{Hdr: hdr, A: net.ParseIP(addr).To4()})
 				case miekgdns.TypeAAAA:
 					m.Answer = append(m.Answer, &miekgdns.AAAA{Hdr: hdr, AAAA: net.ParseIP(addr).To16()})
+				case miekgdns.TypeTXT:
+					m.Answer = append(m.Answer, &miekgdns.TXT{Hdr: hdr, Txt: []string{addr}})
 				}
 			}
 		}

--- a/dns/nameserver.go
+++ b/dns/nameserver.go
@@ -26,19 +26,38 @@ func (n Nameserver) Addr() string {
 	return n.IP.String() + ":" + strconv.Itoa(int(n.Port))
 }
 
-// ParseNameserverAddr parses a nameserver address string into an IP and a port.
+// parseNameserverAddr parses a nameserver address string into an IP and a port.
 //
-// It expects the `addr` to be in the format `ip` or `ip[:port]`. Where `ip` can be an IPv4 or an IPv6 address.
+// It expects the `addr` to be in the format `host` or `host[:port]`. Where `host` can be
+// an IPv4 address, an IPv6 address, or a hostname that will be resolved via the system resolver.
 func parseNameserverAddr(addr string) (Nameserver, error) {
 	hostStr, port, err := parseHostAndPort(addr)
 	if err != nil {
 		return Nameserver{}, err
 	}
 
-	// Parse the host part into an IP
+	// Strip trailing dot from FQDN hostnames
+	hostStr = strings.TrimSuffix(hostStr, ".")
+
+	// Try parsing as IP first
 	ip := net.ParseIP(hostStr)
+	if ip != nil {
+		return Nameserver{ip, port}, nil
+	}
+
+	// Not an IP, try resolving the hostname
+	ips, err := net.LookupHost(hostStr)
+	if err != nil {
+		return Nameserver{}, fmt.Errorf("failed to resolve nameserver hostname %s: %w", hostStr, err)
+	}
+
+	if len(ips) == 0 {
+		return Nameserver{}, fmt.Errorf("nameserver hostname %s resolved to no addresses", hostStr)
+	}
+
+	ip = net.ParseIP(ips[0])
 	if ip == nil {
-		return Nameserver{}, fmt.Errorf("invalid nameserver IP address: %s", hostStr)
+		return Nameserver{}, fmt.Errorf("nameserver hostname %s resolved to invalid IP: %s", hostStr, ips[0])
 	}
 
 	return Nameserver{ip, port}, nil

--- a/dns/nameserver.go
+++ b/dns/nameserver.go
@@ -28,36 +28,17 @@ func (n Nameserver) Addr() string {
 
 // parseNameserverAddr parses a nameserver address string into an IP and a port.
 //
-// It expects the `addr` to be in the format `host` or `host[:port]`. Where `host` can be
-// an IPv4 address, an IPv6 address, or a hostname that will be resolved via the system resolver.
+// It expects the `addr` to be in the format `ip` or `ip[:port]`. Where `ip` can be an IPv4 or an IPv6 address.
 func parseNameserverAddr(addr string) (Nameserver, error) {
 	hostStr, port, err := parseHostAndPort(addr)
 	if err != nil {
 		return Nameserver{}, err
 	}
 
-	// Strip trailing dot from FQDN hostnames
-	hostStr = strings.TrimSuffix(hostStr, ".")
-
-	// Try parsing as IP first
+	// Parse the host part into an IP
 	ip := net.ParseIP(hostStr)
-	if ip != nil {
-		return Nameserver{ip, port}, nil
-	}
-
-	// Not an IP, try resolving the hostname
-	ips, err := net.LookupHost(hostStr)
-	if err != nil {
-		return Nameserver{}, fmt.Errorf("failed to resolve nameserver hostname %s: %w", hostStr, err)
-	}
-
-	if len(ips) == 0 {
-		return Nameserver{}, fmt.Errorf("nameserver hostname %s resolved to no addresses", hostStr)
-	}
-
-	ip = net.ParseIP(ips[0])
 	if ip == nil {
-		return Nameserver{}, fmt.Errorf("nameserver hostname %s resolved to invalid IP: %s", hostStr, ips[0])
+		return Nameserver{}, fmt.Errorf("invalid nameserver IP address: %s", hostStr)
 	}
 
 	return Nameserver{ip, port}, nil

--- a/dns/record_type.go
+++ b/dns/record_type.go
@@ -32,4 +32,5 @@ type RecordType uint16
 const (
 	RecordTypeA    = RecordType(dns.TypeA)
 	RecordTypeAAAA = RecordType(dns.TypeAAAA)
+	RecordTypeTXT  = RecordType(dns.TypeTXT)
 )

--- a/dns/record_type_gen.go
+++ b/dns/record_type_gen.go
@@ -8,30 +8,35 @@ import (
 
 const (
 	_RecordTypeName_0 = "A"
-	_RecordTypeName_1 = "AAAA"
+	_RecordTypeName_1 = "TXT"
+	_RecordTypeName_2 = "AAAA"
 )
 
 var (
 	_RecordTypeIndex_0 = [...]uint8{0, 1}
-	_RecordTypeIndex_1 = [...]uint8{0, 4}
+	_RecordTypeIndex_1 = [...]uint8{0, 3}
+	_RecordTypeIndex_2 = [...]uint8{0, 4}
 )
 
 func (i RecordType) String() string {
 	switch {
 	case i == 1:
 		return _RecordTypeName_0
-	case i == 28:
+	case i == 16:
 		return _RecordTypeName_1
+	case i == 28:
+		return _RecordTypeName_2
 	default:
 		return fmt.Sprintf("RecordType(%d)", i)
 	}
 }
 
-var _RecordTypeValues = []RecordType{1, 28}
+var _RecordTypeValues = []RecordType{1, 16, 28}
 
 var _RecordTypeNameToValueMap = map[string]RecordType{
 	_RecordTypeName_0[0:1]: 1,
-	_RecordTypeName_1[0:4]: 28,
+	_RecordTypeName_1[0:3]: 16,
+	_RecordTypeName_2[0:4]: 28,
 }
 
 // RecordTypeString retrieves an enum value from the enum constants string name.

--- a/example.js
+++ b/example.js
@@ -9,6 +9,9 @@ export default async function () {
     const resolveResults = await dns.resolve("k6.io", "A", "1.1.1.1:53");
     // console.log(`resolved the k6.io domain using cloudflare dns servers to the following IPs: ${resolveResults}`);
 
+    const txtResults = await dns.resolve("k6.io", "TXT", "1.1.1.1:53");
+    // console.log(`resolved the k6.io domain TXT records: ${txtResults}`);
+
     const lookupResults = await dns.lookup("k6.io");
     // console.log(`looking up the k6.io domain using system defined dns servers to the following IPs: ${resolveResults}`);
 }


### PR DESCRIPTION
This PR adds support to TXT record type to xk6-dns.

I am just extending the existing logic to support TXT entries alongside the other record types. The implementation follows the same patterns already in place, so it should feel pretty consistent with the rest of the codebase.

Tested with a few sample records to make sure everything parses and behaves as expected.

Let me know if you’d like me to add more test cases or cover additional edge cases