### PR TITLE
build: pin go toolchain to latest patch version for security

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/grafana/xk6-dns
 
 go 1.25.0
 
+toolchain go1.25.10
+
 require (
 	github.com/docker/go-connections v0.6.0
 	github.com/grafana/sobek v0.0.0-20260331145705-2272ac4993ef


### PR DESCRIPTION
Pin the Go toolchain in go.mod to the latest patch version of the minor it currently targets, picking up the latest security and bugfix releases.