### PR TITLE
feat: add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# by default the k6-core team is the owner of all files
+* @grafana/k6-core


### PR DESCRIPTION
This pull request makes a small update to the `CODEOWNERS` file, setting the `@grafana/k6-core` team as the default owner for all files.