### PR TITLE
Add support for NAPTR record

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ xk6 build --with github.com/grafana/xk6-dns
 
 ### Example k6 script
 
-From there we can use the bustom built binary to run the following example script:
+From there we can use the custom built binary to run the following example script:
 
 ```javascript
 import dns from 'k6/x/dns';
@@ -43,6 +43,10 @@ export default async function() {
     // Request the TXT records for k6.io from the selected nameserver.
     const txtRecords = await dns.resolve('k6.io', 'TXT', '9.9.9.9:53');
     console.log(`k6.io TXT records: ${txtRecords}`);
+
+    // Request NAPTR records (for example ENUM lookups) from the selected nameserver.
+    const naptrRecords = await dns.resolve('1.2.3.4.e164.arpa', 'NAPTR', '9.9.9.9:53');
+    console.log(`NAPTR records: ${naptrRecords}`);
     
     // Lookup the IP address of k6.io using the system's default DNS server.
     const lookupIP = await dns.lookup('k6.io');
@@ -85,9 +89,9 @@ default ✓ [======================================] 10 VUs  00m00.2s/10m0s  200
 
 ### `dns.resolve(query, recordType, options)`
 
-Resolves a DNS query using the provided DNS server. It returns an array of results: IP addresses for `A`/`AAAA` records, or strings for `TXT` records.
+Resolves a DNS query using the provided DNS server. It returns an array of results: IP addresses for `A`/`AAAA` records, or strings for `TXT`/`NAPTR` records.
 
-The `query` parameter is the DNS name to resolve, the `recordType` parameter is the type of DNS record to query for (e.g. 'A', 'AAAA', 'TXT'), and the `options` parameter is an object that can contain the following properties:
+The `query` parameter is the DNS name to resolve, the `recordType` parameter is the type of DNS record to query for (e.g. 'A', 'AAAA', 'TXT', 'NAPTR'), and the `options` parameter is an object that can contain the following properties:
 - `nameserver` - the IP address and port of the DNS server to query. It should be in the format `ip:port`. If not provided, the system's default DNS server will be used.
 
 Using the `dns.resolve()` operation will emit the following metrics:

--- a/dns/client.go
+++ b/dns/client.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -286,12 +285,8 @@ func (r *Client) ensureK6Client() (err error) {
 	return err
 }
 
-// Format NAPTR answer.
+// fmtNAPTRAnswer formats a NAPTR answer in DNS presentation format (rdata only).
+// It reuses miekg/dns's NAPTR.String() and strips the RR header prefix.
 func fmtNAPTRAnswer(answer *dns.NAPTR) string {
-	return strconv.Itoa(int(answer.Order)) + " " +
-		strconv.Itoa(int(answer.Preference)) + " " +
-		"\"" + answer.Flags + "\" " +
-		"\"" + answer.Service + "\" " +
-		"\"" + answer.Regexp + "\" " +
-		answer.Replacement
+	return strings.TrimPrefix(answer.String(), answer.Hdr.String())
 }

--- a/dns/client.go
+++ b/dns/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -126,6 +127,8 @@ func (r *Client) Resolve(
 			results = append(results, t.AAAA.String())
 		case *dns.TXT:
 			results = append(results, strings.Join(t.Txt, ""))
+		case *dns.NAPTR:
+			results = append(results, fmtNAPTRAnswer(t))
 		default:
 			return nil, fmt.Errorf(
 				"resolve operation failed with %w: unhandled DNS answer type %T",
@@ -281,4 +284,14 @@ func (r *Client) ensureK6Client() (err error) {
 	})
 
 	return err
+}
+
+// Format NAPTR answer.
+func fmtNAPTRAnswer(answer *dns.NAPTR) string {
+	return strconv.Itoa(int(answer.Order)) + " " +
+		strconv.Itoa(int(answer.Preference)) + " " +
+		"\"" + answer.Flags + "\" " +
+		"\"" + answer.Service + "\" " +
+		"\"" + answer.Regexp + "\" " +
+		answer.Replacement
 }

--- a/dns/module_test.go
+++ b/dns/module_test.go
@@ -3,6 +3,7 @@ package dns
 import (
 	"context"
 	"net"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -53,6 +54,10 @@ const (
 	// primaryTestTXT is a TXT record value we configure our test DNS server to resolve
 	// the testDomain to.
 	primaryTestTXT = "v=spf1 include:example.com ~all"
+
+	// primaryTestNAPTR is a default NAPTR response we configure our DNS server to
+	// resolve the testDomain to.
+	primaryTestNAPTR = "100 10 \"U\" \"E2U+sip\" \"!^.*$!sip:customer-service@example.com!\" ."
 )
 
 func TestClient_Resolve(t *testing.T) {
@@ -302,6 +307,68 @@ func TestClient_Resolve(t *testing.T) {
 			}
 		
 			throw "Resolving missing.domain TXT against test nameserver should have thrown an error, but it didn't"
+		`
+
+		_, err = runtime.RunOnEventLoop(wrapInAsyncLambda(testScript))
+		assert.NoError(t, err)
+	})
+
+	t.Run("Resolving existing NAPTR records against test nameserver should succeed", func(t *testing.T) {
+		t.Parallel()
+
+		port, _ := startTestDNSServer(t)
+
+		runtime, err := newConfiguredRuntime(t)
+		require.NoError(t, err)
+
+		runtime.MoveToVUContext(newTestVUState())
+
+		testScript := `
+			const resolveResults = await dns.resolve(
+				"` + testDomain + `",
+				"` + RecordTypeNAPTR.String() + `",
+				"127.0.0.1:` + port + `"
+			);
+		
+			if (resolveResults.length === 0) {
+				throw "Resolving ` + testDomain + ` NAPTR against test nameserver returned no results, expected at least one NAPTR record"
+			}
+		
+			if (resolveResults[0] !== ` + strconv.Quote(primaryTestNAPTR) + `) {
+				throw "Resolving ` + testDomain + ` NAPTR against test nameserver returned unexpected result, expected " + ` + strconv.Quote(primaryTestNAPTR) + ` + ", got " + resolveResults[0]
+			}
+		`
+
+		_, err = runtime.RunOnEventLoop(wrapInAsyncLambda(testScript))
+		assert.NoError(t, err)
+	})
+
+	t.Run("Resolving non-existing NAPTR records against test nameserver should succeed", func(t *testing.T) {
+		t.Parallel()
+
+		port, _ := startTestDNSServer(t)
+
+		runtime, err := newConfiguredRuntime(t)
+		require.NoError(t, err)
+
+		runtime.MoveToVUContext(newTestVUState())
+
+		testScript := `
+			try {
+				const resolvedResults = await dns.resolve(
+					"missing.domain",
+					"` + RecordTypeNAPTR.String() + `",
+					"127.0.0.1:` + port + `"
+				);
+			} catch (err) {
+				if (err.name !== "NonExistingDomain") {
+					throw "Resolving missing.domain NAPTR against test nameserver returned unexpected error, expected NonExistingDomain, got: " + err.name
+				}
+		
+				return
+			}
+		
+			throw "Resolving missing.domain NAPTR against test nameserver should have thrown an error, but it didn't"
 		`
 
 		_, err = runtime.RunOnEventLoop(wrapInAsyncLambda(testScript))
@@ -812,9 +879,9 @@ func wrapInAsyncLambda(input string) string {
 }
 
 // startTestDNSServer starts small UDP DNS servers on random ports of
-// 127.0.0.1 and [::1] sharing the same handler — they answer A/AAAA/TXT queries
-// for testDomain with the test IPs and TXT records, and return NXDOMAIN for anything else.
-// Both listeners shut down via t.Cleanup.
+// 127.0.0.1 and [::1] sharing the same handler — they answer A/AAAA/TXT/NAPTR
+// queries for testDomain with the test IPs and records, and return NXDOMAIN for
+// anything else. Both listeners shut down via t.Cleanup.
 //
 // In-process via miekg/dns; no Docker dependency, works identically on every
 // platform that has loopback (which is every platform).
@@ -822,9 +889,10 @@ func startTestDNSServer(t *testing.T) (ipv4Port, ipv6Port string) {
 	t.Helper()
 
 	records := map[uint16][]string{
-		miekgdns.TypeA:    {primaryTestIPv4, secondaryTestIPv4},
-		miekgdns.TypeAAAA: {primaryTestIPv6, secondaryTestIPv6},
-		miekgdns.TypeTXT:  {primaryTestTXT},
+		miekgdns.TypeA:     {primaryTestIPv4, secondaryTestIPv4},
+		miekgdns.TypeAAAA:  {primaryTestIPv6, secondaryTestIPv6},
+		miekgdns.TypeTXT:   {primaryTestTXT},
+		miekgdns.TypeNAPTR: {primaryTestNAPTR},
 	}
 
 	handler := miekgdns.HandlerFunc(func(w miekgdns.ResponseWriter, r *miekgdns.Msg) {
@@ -844,6 +912,16 @@ func startTestDNSServer(t *testing.T) (ipv4Port, ipv6Port string) {
 					m.Answer = append(m.Answer, &miekgdns.AAAA{Hdr: hdr, AAAA: net.ParseIP(addr).To16()})
 				case miekgdns.TypeTXT:
 					m.Answer = append(m.Answer, &miekgdns.TXT{Hdr: hdr, Txt: []string{addr}})
+				case miekgdns.TypeNAPTR:
+					m.Answer = append(m.Answer, &miekgdns.NAPTR{
+						Hdr:         hdr,
+						Order:       100,
+						Preference:  10,
+						Flags:       "U",
+						Service:     "E2U+sip",
+						Regexp:      "!^.*$!sip:customer-service@example.com!",
+						Replacement: ".",
+					})
 				}
 			}
 		}

--- a/dns/module_test.go
+++ b/dns/module_test.go
@@ -3,7 +3,6 @@ package dns
 import (
 	"context"
 	"net"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -333,9 +332,10 @@ func TestClient_Resolve(t *testing.T) {
 			if (resolveResults.length === 0) {
 				throw "Resolving ` + testDomain + ` NAPTR against test nameserver returned no results, expected at least one NAPTR record"
 			}
-		
-			if (resolveResults[0] !== ` + strconv.Quote(primaryTestNAPTR) + `) {
-				throw "Resolving ` + testDomain + ` NAPTR against test nameserver returned unexpected result, expected " + ` + strconv.Quote(primaryTestNAPTR) + ` + ", got " + resolveResults[0]
+
+			const expected = '` + primaryTestNAPTR + `';
+			if (resolveResults[0] !== expected) {
+				throw "Resolving ` + testDomain + ` NAPTR against test nameserver returned unexpected result, expected '" + expected + "', got " + resolveResults[0]
 			}
 		`
 

--- a/dns/record_type.go
+++ b/dns/record_type.go
@@ -10,6 +10,8 @@ import "github.com/miekg/dns"
 // The currently supported values are:
 // - A
 // - AAAA
+// - TXT
+// - NAPTR
 //
 // The supported values are the ones that are most likely to be
 // used by the users of this extension and package, as they are
@@ -30,7 +32,8 @@ type RecordType uint16
 // Note that the RecordType enum values are explicitly typed to allow enumer
 // to detect them.
 const (
-	RecordTypeA    = RecordType(dns.TypeA)
-	RecordTypeAAAA = RecordType(dns.TypeAAAA)
-	RecordTypeTXT  = RecordType(dns.TypeTXT)
+	RecordTypeA     = RecordType(dns.TypeA)
+	RecordTypeAAAA  = RecordType(dns.TypeAAAA)
+	RecordTypeTXT   = RecordType(dns.TypeTXT)
+	RecordTypeNAPTR = RecordType(dns.TypeNAPTR)
 )

--- a/dns/record_type_gen.go
+++ b/dns/record_type_gen.go
@@ -10,12 +10,14 @@ const (
 	_RecordTypeName_0 = "A"
 	_RecordTypeName_1 = "TXT"
 	_RecordTypeName_2 = "AAAA"
+	_RecordTypeName_3 = "NAPTR"
 )
 
 var (
 	_RecordTypeIndex_0 = [...]uint8{0, 1}
 	_RecordTypeIndex_1 = [...]uint8{0, 3}
 	_RecordTypeIndex_2 = [...]uint8{0, 4}
+	_RecordTypeIndex_3 = [...]uint8{0, 5}
 )
 
 func (i RecordType) String() string {
@@ -26,17 +28,20 @@ func (i RecordType) String() string {
 		return _RecordTypeName_1
 	case i == 28:
 		return _RecordTypeName_2
+	case i == 35:
+		return _RecordTypeName_3
 	default:
 		return fmt.Sprintf("RecordType(%d)", i)
 	}
 }
 
-var _RecordTypeValues = []RecordType{1, 16, 28}
+var _RecordTypeValues = []RecordType{1, 16, 28, 35}
 
 var _RecordTypeNameToValueMap = map[string]RecordType{
 	_RecordTypeName_0[0:1]: 1,
 	_RecordTypeName_1[0:3]: 16,
 	_RecordTypeName_2[0:4]: 28,
+	_RecordTypeName_3[0:5]: 35,
 }
 
 // RecordTypeString retrieves an enum value from the enum constants string name.


### PR DESCRIPTION
This PR add support for NAPTR record type.
NAPTR query takes an E164 phone number (0123456789) in the format of "9.8.7.6.5.4.3.2.1.0.e164.arpa.", and return a record pertaining to routing the phone number to the correct service provider (100 10 "U" "E2U+sip" "!^.*$!sip:[customer-service@example.com](mailto:customer-service@example.com)!" .)